### PR TITLE
Fix issue with endpoint to get methods

### DIFF
--- a/pypot/server/httpserver.py
+++ b/pypot/server/httpserver.py
@@ -184,7 +184,7 @@ class SetPrimitivePropertyHandler(PoppyRequestHandler):
 class ListPrimitiveMethodsHandler(PoppyRequestHandler):
     def get(self, primitive_name):
         self.write_json({
-            'methods': self.restful_robot.get_primitive_methods_list(self, primitive_name)
+            'methods': self.restful_robot.get_primitive_methods_list(primitive_name)
         })
 
 


### PR DESCRIPTION
The endpoint to get the methods from a primitive had an issue where the method
"get_primitive_methods_list" was being called with an extra parameter (self), causing
it to fail and not return the expected result.